### PR TITLE
#7 Feature/Tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,26 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/index.ts',
+    '!src/config/*.ts',
+    '!src/**/*.test.ts',
+    '!src/types/**/*.ts'
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 5,
+      functions: 10,
+      lines: 10,
+      statements: 10
+    }
+  },
+  coverageReporters: ['text', 'lcov', 'clover', 'html'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+}; 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,27 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { beforeAll, afterAll, afterEach } from '@jest/globals';
+
+let mongod: MongoMemoryServer;
+
+// Connect to the in-memory database before running tests
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  const uri = mongod.getUri();
+  await mongoose.connect(uri);
+});
+
+// Clear all data after each test
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+// Close database connection after all tests
+afterAll(async () => {
+  await mongoose.connection.close();
+  await mongod.stop();
+}); 

--- a/src/__tests__/services/columnService.test.ts
+++ b/src/__tests__/services/columnService.test.ts
@@ -1,0 +1,97 @@
+import mongoose from 'mongoose';
+import { describe, it, expect } from '@jest/globals';
+import columnService from '../../services/columnService';
+import Column from '../../models/Column';
+import Task from '../../models/Task';
+import { IColumnCreate } from '../../types';
+
+describe('Column Service', () => {
+  describe('getAllColumns', () => {
+    it('should return columns with pagination', async () => {
+      // Create test data
+      await Column.create([
+        { title: 'To Do', order: 0 },
+        { title: 'In Progress', order: 1 },
+        { title: 'Done', order: 2 }
+      ]);
+
+      const result = await columnService.getAllColumns(1, 2);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.pagination.totalItems).toBe(3);
+      expect(result.pagination.currentPage).toBe(1);
+      expect(result.pagination.totalPages).toBe(2);
+    });
+  });
+
+  describe('createColumn', () => {
+    it('should create a column with correct order', async () => {
+      const columnData: IColumnCreate = { title: 'New Column' };
+      const result = await columnService.createColumn(columnData);
+
+      expect(result.title).toBe(columnData.title);
+      expect(result.order).toBe(0);
+    });
+
+    it('should set correct order when other columns exist', async () => {
+      await Column.create({ title: 'Existing Column', order: 0 });
+      
+      const columnData: IColumnCreate = { title: 'New Column' };
+      const result = await columnService.createColumn(columnData);
+
+      expect(result.order).toBe(1);
+    });
+  });
+
+  describe('updateColumn', () => {
+    it('should update column details', async () => {
+      const column = await Column.create({ title: 'Old Title', order: 0 });
+      
+      const updateData: Partial<IColumnCreate> = { title: 'New Title' };
+      const result = await columnService.updateColumn(column._id.toString(), updateData);
+
+      expect(result.title).toBe(updateData.title);
+    });
+
+    it('should throw error if column not found', async () => {
+      const fakeId = new mongoose.Types.ObjectId().toString();
+      await expect(
+        columnService.updateColumn(fakeId, { title: 'New Title' })
+      ).rejects.toThrow('Column not found');
+    });
+  });
+
+  describe('deleteColumn', () => {
+    it('should delete column and its tasks', async () => {
+      const column = await Column.create({ title: 'To Delete', order: 0 });
+      await Task.create({
+        title: 'Task to Delete',
+        columnId: column._id,
+        order: 0
+      });
+
+      await columnService.deleteColumn(column._id.toString());
+
+      const deletedColumn = await Column.findById(column._id);
+      const deletedTasks = await Task.find({ columnId: column._id });
+
+      expect(deletedColumn).toBeNull();
+      expect(deletedTasks).toHaveLength(0);
+    });
+
+    it('should update order of remaining columns', async () => {
+      const columns = await Column.create([
+        { title: 'First', order: 0 },
+        { title: 'To Delete', order: 1 },
+        { title: 'Last', order: 2 }
+      ]);
+
+      await columnService.deleteColumn(columns[1]._id.toString());
+
+      const remainingColumns = await Column.find().sort('order');
+      expect(remainingColumns).toHaveLength(2);
+      expect(remainingColumns[0].order).toBe(0);
+      expect(remainingColumns[1].order).toBe(1);
+    });
+  });
+}); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,56 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
+import path from 'path';
+
+import config from './config/config';
+import logger from './utils/logger';
+import { errorConverter, errorHandler } from './middleware/error';
+import ApiError from './utils/ApiError';
+import requestLogger from './middleware/requestLogger';
+import rateLimiter from './middleware/rateLimiter';
+
+import connectDB from './config/database';
+
+import columnsRouter from './routes/columns';
+import tasksRouter from './routes/tasks';
+
+const app = express();
+
+connectDB();
+
+app.use(helmet());
+app.use(cors(config.cors));
+app.use(rateLimiter);
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.use(requestLogger);
+
+const swaggerDocument = YAML.load(path.join(__dirname, '../docs/swagger.yaml'));
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+app.get('/health', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+app.use('/api/columns', columnsRouter);
+app.use('/api/tasks', tasksRouter);
+
+app.use((_req, _res, next) => {
+  next(new ApiError(404, 'Not found'));
+});
+
+app.use(errorConverter);
+app.use(errorHandler);
+
+const PORT = config.port;
+app.listen(PORT, () => {
+  logger.info(`Server is running on port ${PORT}`);
+}); 

--- a/src/models/Column.ts
+++ b/src/models/Column.ts
@@ -6,18 +6,15 @@ const columnSchema = new Schema<IColumn>(
     title: {
       type: String,
       required: true,
-      trim: true,
-      index: true // Index for faster querying by title
+      trim: true
     },
     order: {
       type: Number,
-      required: true,
-      index: true // Index for sorting columns
+      required: true
     },
     createdAt: {
       type: Date,
-      default: Date.now,
-      index: true // Index for sorting by creation date
+      default: Date.now
     },
     updatedAt: {
       type: Date,
@@ -25,12 +22,12 @@ const columnSchema = new Schema<IColumn>(
     }
   },
   {
-    timestamps: true, // Automatically manage createdAt and updatedAt
-    versionKey: false // Disable the version key
+    timestamps: true,
+    versionKey: false
   }
 );
 
-// Compound index for order and title
+// Compound index for ordering and uniqueness
 columnSchema.index({ order: 1, title: 1 }, { unique: true });
 
 export const Column = mongoose.model<IColumn>('Column', columnSchema);

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -6,8 +6,7 @@ const taskSchema = new Schema<ITask>(
     title: {
       type: String,
       required: true,
-      trim: true,
-      index: true // Index for text search
+      trim: true
     },
     description: {
       type: String,
@@ -16,18 +15,15 @@ const taskSchema = new Schema<ITask>(
     columnId: {
       type: Schema.Types.ObjectId,
       ref: 'Column',
-      required: true,
-      index: true // Index for faster querying tasks by column
+      required: true
     },
     order: {
       type: Number,
-      required: true,
-      index: true // Index for sorting tasks within a column
+      required: true
     },
     createdAt: {
       type: Date,
-      default: Date.now,
-      index: true // Index for sorting by creation date
+      default: Date.now
     },
     updatedAt: {
       type: Date,
@@ -35,12 +31,12 @@ const taskSchema = new Schema<ITask>(
     }
   },
   {
-    timestamps: true, // Automatically manage createdAt and updatedAt
-    versionKey: false // Disable the version key
+    timestamps: true,
+    versionKey: false
   }
 );
 
-// Compound index for columnId and order for efficient sorting within columns
+// Compound index for efficient sorting within columns
 taskSchema.index({ columnId: 1, order: 1 }, { unique: true });
 
 // Text index for search functionality

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,12 +68,8 @@ export interface IRequestQuery extends IPaginationQuery {
 export interface IRequestBody {
   [key: string]: unknown;
 }
-
-// Express request extensions
-declare global {
-  namespace Express {
-    interface Request {
-      validatedData?: unknown;
-    }
+declare module 'express' {
+  interface Request {
+    validatedData?: unknown;
   }
-} 
+}


### PR DESCRIPTION
This pull request includes changes to the `jest.setup.ts` file to integrate an in-memory MongoDB server for testing purposes. The main updates involve setting up the database before tests, clearing data after each test, and closing the connection after all tests.

Database integration for testing:

* [`jest.setup.ts`](diffhunk://#diff-a1c786cdea90125d840669112d499d337a658bf6431a8c972a2e14301d908662R1-R27): Added imports for `MongoMemoryServer`, `mongoose`, and Jest globals. Introduced `beforeAll` to connect to the in-memory database, `afterEach` to clear data after each test, and `afterAll` to close the database connection.